### PR TITLE
Fix wifi reconnect

### DIFF
--- a/src/OTA.cpp
+++ b/src/OTA.cpp
@@ -67,6 +67,9 @@ void OTA::pollWifiState()
     else
     {
       // a device has disconnected from the AP, and we are back in listening mode
+      // Reset server with server.begin() to accept new connections
+      // https://github.com/arduino-libraries/WiFi101/issues/110#issuecomment-256662397
+      server.begin();
       LOG.println("Device disconnected from AP");
       led_interval = 2000;
     }

--- a/src/OTA.h
+++ b/src/OTA.h
@@ -33,7 +33,7 @@ class OTA {
         void pollWifiState();
         bool handlePostSketch(WiFiClient& client, String& req_str);
         void stopHardware();
-        void handlePing()(WiFiClient client);
+        void handlePing(WiFiClient client);
 
         byte mac[6];
         int status;


### PR DESCRIPTION
While testing our iOS App it was only possible to connect once by WiFi.
After disconnecting and connecting again it was not possible to call `GET /ping`.

Found following issue https://github.com/arduino-libraries/WiFi101/issues/110#issuecomment-256662397 and calling `server.begin()` after a disconnect fixed the issue.